### PR TITLE
Replace invalid .css & .js reference in header.html

### DIFF
--- a/luigi/templates/header.html
+++ b/luigi/templates/header.html
@@ -1,4 +1,4 @@
 <!doctype html>
 <title>Luigi Task History</title>
-<link href="/static/visualiser/lib/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-<script src="/static/visualiser/lib/bootstrap/js/bootstrap.min.js"></script>
+<link href="/static/visualiser/lib/bootstrap3/css/bootstrap.min.css" rel="stylesheet">
+<script src="/static/visualiser/lib/bootstrap3/js/bootstrap.min.js"></script>


### PR DESCRIPTION
It seems the Admin LTE styled visualizer broke the css/js references in http://127.0.0.1:8082/history. This replaces the invalid references with the valid css/js shared by the Admin LTE visualizer.
